### PR TITLE
fix: allow string attributes to be used by loaders

### DIFF
--- a/pyTigerGraph/gds/dataloaders.py
+++ b/pyTigerGraph/gds/dataloaders.py
@@ -1228,7 +1228,7 @@ class NeighborLoader(BaseLoader):
                 v_attr_types = self._v_schema[vtype]
                 if v_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                        "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                         for attr in v_attr_names
                     )
                     print_query_seed += '{} s.type == "{}" THEN \n @@v_batch += (s.type + "," + int_to_string(getvid(s)) + "," + {} + ",1\\n")\n'.format(
@@ -1256,7 +1256,7 @@ class NeighborLoader(BaseLoader):
                 e_attr_types = self._e_schema[etype]
                 if e_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                        "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                         for attr in e_attr_names
                     )
                     print_query += '{} e.type == "{}" THEN \n @@e_batch += (e.type + "," + int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + "\\n")\n'.format(
@@ -1274,7 +1274,7 @@ class NeighborLoader(BaseLoader):
             v_attr_types = next(iter(self._v_schema.values()))
             if v_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                    "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                     for attr in v_attr_names
                 )
                 print_query = '@@v_batch += (int_to_string(getvid(s)) + "," + {} + ",1\\n")'.format(
@@ -1296,7 +1296,7 @@ class NeighborLoader(BaseLoader):
             e_attr_types = next(iter(self._e_schema.values()))
             if e_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                    "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                     for attr in e_attr_names
                 )
                 print_query = '@@e_batch += (int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + "\\n")'.format(
@@ -1662,7 +1662,7 @@ class EdgeLoader(BaseLoader):
                 e_attr_types = self._e_schema[etype]
                 if e_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                        "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                         for attr in e_attr_names
                     )
                     print_query += '{} e.type == "{}" THEN \n @@e_batch += (e.type + "," + int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + "\\n")\n'.format(
@@ -1680,7 +1680,7 @@ class EdgeLoader(BaseLoader):
             e_attr_types = next(iter(self._e_schema.values()))
             if e_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                    "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                     for attr in e_attr_names
                 )
                 print_query = '@@e_batch += (int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + "\\n")'.format(
@@ -1970,7 +1970,7 @@ class VertexLoader(BaseLoader):
                 v_attr_types = self._v_schema[vtype]
                 if v_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                        "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                         for attr in v_attr_names
                     )
                     print_query += '{} s.type == "{}" THEN \n @@v_batch += (s.type + "," + int_to_string(getvid(s)) + "," + {} + "\\n")\n'.format(
@@ -1988,7 +1988,7 @@ class VertexLoader(BaseLoader):
             v_attr_types = next(iter(self._v_schema.values()))
             if v_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                    "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                     for attr in v_attr_names
                 )
                 print_query = '@@v_batch += (int_to_string(getvid(s)) + "," + {} + "\\n")'.format(
@@ -2307,7 +2307,7 @@ class GraphLoader(BaseLoader):
                 v_attr_types = self._v_schema[vtype]
                 if v_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                        "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                         for attr in v_attr_names
                     )
                     print_query += '{} s.type == "{}" THEN \n @@v_batch += (s.type + "," + int_to_string(getvid(s)) + "," + {} + "\\n")\n'.format(
@@ -2329,7 +2329,7 @@ class GraphLoader(BaseLoader):
                 e_attr_types = self._e_schema[etype]
                 if e_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                        "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                         for attr in e_attr_names
                     )
                     print_query += '{} e.type == "{}" THEN \n @@e_batch += (e.type + "," + int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + "\\n")\n'.format(
@@ -2347,7 +2347,7 @@ class GraphLoader(BaseLoader):
             v_attr_types = next(iter(self._v_schema.values()))
             if v_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                    "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                     for attr in v_attr_names
                 )
                 print_query = '@@v_batch += (int_to_string(getvid(s)) + "," + {} + "\\n")'.format(
@@ -2362,7 +2362,7 @@ class GraphLoader(BaseLoader):
             e_attr_types = next(iter(self._e_schema.values()))
             if e_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                    "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                     for attr in e_attr_names
                 )
                 print_query = '@@e_batch += (int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + "\\n")'.format(
@@ -2650,7 +2650,7 @@ class EdgeNeighborLoader(BaseLoader):
                 v_attr_types = self._v_schema[vtype]
                 if v_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                        "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                         for attr in v_attr_names
                     )
                     print_query += '{} s.type == "{}" THEN \n @@v_batch += (s.type + "," + int_to_string(getvid(s)) + "," + {} + "\\n")\n'.format(
@@ -2673,7 +2673,7 @@ class EdgeNeighborLoader(BaseLoader):
                 e_attr_types = self._e_schema[etype]
                 if e_attr_names:
                     print_attr = '+","+'.join(
-                        "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                        "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                         for attr in e_attr_names
                     )
                     print_query_seed += '{} e.type == "{}" THEN \n @@e_batch += (e.type + "," + int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + ",1\\n")\n'.format(
@@ -2697,7 +2697,7 @@ class EdgeNeighborLoader(BaseLoader):
             v_attr_types = next(iter(self._v_schema.values()))
             if v_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(s.{})".format(_udf_funcs[v_attr_types[attr]], attr)
+                    "{}(s.{})".format('' if v_attr_types[attr]=="STRING" else _udf_funcs[v_attr_types[attr]], attr)
                     for attr in v_attr_names
                 )
                 print_query = '@@v_batch += (int_to_string(getvid(s)) + "," + {} + "\\n")'.format(
@@ -2713,7 +2713,7 @@ class EdgeNeighborLoader(BaseLoader):
             e_attr_types = next(iter(self._e_schema.values()))
             if e_attr_names:
                 print_attr = '+","+'.join(
-                    "{}(e.{})".format(_udf_funcs[e_attr_types[attr]], attr)
+                    "{}(e.{})".format('' if e_attr_types[attr]=="STRING" else _udf_funcs[e_attr_types[attr]], attr)
                     for attr in e_attr_names
                 )
                 print_query = '@@e_batch += (int_to_string(getvid(s)) + "," + int_to_string(getvid(t)) + "," + {} + ",1\\n")'.format(

--- a/pyTigerGraph/gds/gds.py
+++ b/pyTigerGraph/gds/gds.py
@@ -216,7 +216,7 @@ class GDS:
                 certain attribute doesn't exist in all vertex types. If it is a dict, keys of the 
                 dict are vertex types to be selected, and values are lists of attributes to be 
                 selected for each vertex type. 
-                All types of attributes are allowed. Defaults to None.
+                Numeric, boolean and string attributes are allowed. Defaults to None.
             e_in_feats (list or dict, optional):
                 Edge attributes to be used as input features. 
                 If it is a list, then the attributes
@@ -239,7 +239,7 @@ class GDS:
                 selected. An error will be thrown if certain attribute doesn't exist in all 
                 edge types. If it is a dict, keys of the dict are edge types to be selected, 
                 and values are lists of attributes to be selected for each edge type.
-                All types of attributes are allowed. Defaults to None.
+                Numeric, boolean and string attributes are allowed. Defaults to None.
             batch_size (int, optional):
                 Number of vertices as seeds in each batch.
                 Defaults to None.
@@ -409,7 +409,8 @@ class GDS:
                 in the list from all edge types will be selected. An error will be thrown if
                 certain attribute doesn't exist in all edge types. If it is a dict, keys of the 
                 dict are edge types to be selected, and values are lists of attributes to be 
-                selected for each edge type. Defaults to None.
+                selected for each edge type. Numeric, boolean and string attributes are allowed.
+                Defaults to None.
             batch_size (int, optional):
                 Number of edges in each batch.
                 Defaults to None.
@@ -562,7 +563,8 @@ class GDS:
                 in the list from all vertex types will be selected. An error will be thrown if
                 certain attribute doesn't exist in all vertex types. If it is a dict, keys of the 
                 dict are vertex types to be selected, and values are lists of attributes to be 
-                selected for each vertex type. Defaults to None.
+                selected for each vertex type. Numeric, boolean and string attributes are allowed.
+                Defaults to None.
             batch_size (int, optional):
                 Number of vertices in each batch.
                 Defaults to None.
@@ -743,7 +745,7 @@ class GDS:
                 certain attribute doesn't exist in all vertex types. If it is a dict, keys of the 
                 dict are vertex types to be selected, and values are lists of attributes to be 
                 selected for each vertex type. 
-                All types of attributes are allowed. Defaults to None.
+                Numeric, boolean and string attributes are allowed. Defaults to None.
             e_in_feats (list or dict, optional):
                 Edge attributes to be used as input features. 
                 If it is a list, then the attributes
@@ -766,7 +768,7 @@ class GDS:
                 selected. An error will be thrown if certain attribute doesn't exist in all 
                 edge types. If it is a dict, keys of the dict are edge types to be selected, 
                 and values are lists of attributes to be selected for each edge type.
-                All types of attributes are allowed. Defaults to None.
+                Numeric, boolean and string attributes are allowed. Defaults to None.
             batch_size (int, optional):
                 Number of edges in each batch.
                 Defaults to None.
@@ -960,7 +962,7 @@ class GDS:
                 certain attribute doesn't exist in all vertex types. If it is a dict, keys of the 
                 dict are vertex types to be selected, and values are lists of attributes to be 
                 selected for each vertex type. 
-                All types of attributes are allowed. Defaults to None.
+                Numeric, boolean and string attributes are allowed. Defaults to None.
             e_in_feats (list or dict, optional):
                 Edge attributes to be used as input features. 
                 If it is a list, then the attributes
@@ -983,7 +985,7 @@ class GDS:
                 selected. An error will be thrown if certain attribute doesn't exist in all 
                 edge types. If it is a dict, keys of the dict are edge types to be selected, 
                 and values are lists of attributes to be selected for each edge type.
-                All types of attributes are allowed. Defaults to None.
+                Numeric, boolean and string attributes are allowed. Defaults to None.
             batch_size (int, optional):
                 Number of vertices as seeds in each batch.
                 Defaults to None.

--- a/tests/test_gds_GraphLoader.py
+++ b/tests/test_gds_GraphLoader.py
@@ -298,6 +298,32 @@ class TestGDSGraphLoaderREST(unittest.TestCase):
             num_batches += 1
         self.assertEqual(num_batches, 11)
 
+    def test_string_attr(self):
+        conn = TigerGraphConnection(host="http://35.230.92.92", graphname="Cora2")
+        loader = GraphLoader(
+            graph=conn,
+            v_in_feats=["x"],
+            v_out_labels=["y"],
+            v_extra_feats=["train_mask", "val_mask", "test_mask", "name"],
+            num_batches=1,
+            shuffle=False,
+            filter_by="train_mask",
+            output_format="PyG",
+            add_self_loop=False,
+            loader_id=None,
+            buffer_size=4,
+        )
+        data = loader.data
+        # print(data)
+        # print(data.name)
+        self.assertIsInstance(data, pygData)
+        self.assertIn("x", data)
+        self.assertIn("y", data)
+        self.assertIn("train_mask", data)
+        self.assertIn("val_mask", data)
+        self.assertIn("test_mask", data)
+        self.assertIn("name", data)
+
 
 class TestGDSHeteroGraphLoaderREST(unittest.TestCase):
     @classmethod
@@ -429,6 +455,7 @@ if __name__ == "__main__":
     suite.addTest(TestGDSGraphLoaderREST("test_iterate_pyg"))
     suite.addTest(TestGDSGraphLoaderREST("test_iterate_df"))
     suite.addTest(TestGDSGraphLoaderREST("test_edge_attr"))
+    suite.addTest(TestGDSGraphLoaderREST("test_string_attr"))
     suite.addTest(TestGDSHeteroGraphLoaderREST("test_init"))
     suite.addTest(TestGDSHeteroGraphLoaderREST("test_iterate_pyg"))
     suite.addTest(TestGDSHeteroGraphLoaderREST("test_iterate_df"))

--- a/tests/test_gds_VertexLoader.py
+++ b/tests/test_gds_VertexLoader.py
@@ -186,6 +186,26 @@ class TestGDSVertexLoaderREST(unittest.TestCase):
         self.assertIn("val_mask", data.columns)
         self.assertIn("test_mask", data.columns)
 
+    def test_string_attr(self):
+        conn = TigerGraphConnection(host="http://35.230.92.92", graphname="Cora2")
+        loader = VertexLoader(
+            graph=conn,
+            attributes=["y", "train_mask", "val_mask", "test_mask", "name"],
+            num_batches=1,
+            shuffle=False,
+            filter_by="train_mask",
+            loader_id=None,
+            buffer_size=4,
+        )
+        data = loader.data
+        # print(data.head())
+        self.assertIsInstance(data, DataFrame)
+        self.assertIn("y", data.columns)
+        self.assertIn("train_mask", data.columns)
+        self.assertIn("val_mask", data.columns)
+        self.assertIn("test_mask", data.columns)
+        self.assertIn("name", data.columns)
+
 
 class TestGDSHeteroVertexLoaderREST(unittest.TestCase):
     @classmethod
@@ -261,6 +281,7 @@ if __name__ == "__main__":
     suite.addTest(TestGDSVertexLoaderREST("test_init"))
     suite.addTest(TestGDSVertexLoaderREST("test_iterate"))
     suite.addTest(TestGDSVertexLoaderREST("test_all_vertices"))
+    suite.addTest(TestGDSVertexLoaderREST("test_string_attr"))
     suite.addTest(TestGDSHeteroVertexLoaderREST("test_init"))
     suite.addTest(TestGDSHeteroVertexLoaderREST("test_iterate"))
     suite.addTest(TestGDSHeteroVertexLoaderREST("test_all_vertices"))


### PR DESCRIPTION
Code change
* Allow string attributes to be pulled by all data loaders.
* Update docs to be explicit about what attribute types are supported.

Testing
* Unit tests added and passed.