### PR TITLE
fix: "None" as key in homogeneou DGL extra data

### DIFF
--- a/pyTigerGraph/gds/dataloaders.py
+++ b/pyTigerGraph/gds/dataloaders.py
@@ -712,18 +712,32 @@ class BaseLoader:
                 dtype = attr_types[col].lower()
                 if dtype.startswith("str"):
                     if mode == "dgl":
-                        if vetype not in graph.extra_data:
+                        if vetype is None:
+                            # Homogeneous graph, add column directly to extra data
+                            graph.extra_data[col] = attr_df[col].to_list()
+                        elif vetype not in graph.extra_data:
+                            # Hetero graph, vetype doesn't exist in extra data
                             graph.extra_data[vetype] = {}
-                        graph.extra_data[vetype][col] = attr_df[col].to_list()
+                            graph.extra_data[vetype][col] = attr_df[col].to_list()
+                        else: 
+                            # Hetero graph and vetype already exists
+                            graph.extra_data[vetype][col] = attr_df[col].to_list()
                     elif mode == "pyg" or mode == "spektral":
                         data[col] = attr_df[col].to_list()
                 elif dtype.startswith("list"):
                     dtype2 = dtype.split(":")[1]
                     if dtype2.startswith("str"):
                         if mode == "dgl":
-                            if vetype not in graph.extra_data:
+                            if vetype is None:
+                                # Homogeneous graph, add column directly to extra data
+                                graph.extra_data[col] = attr_df[col].str.split().to_list()
+                            elif vetype not in graph.extra_data:
+                                # Hetero graph, vetype doesn't exist in extra data
                                 graph.extra_data[vetype] = {}
-                            graph.extra_data[vetype][col] = attr_df[col].str.split().to_list()
+                                graph.extra_data[vetype][col] = attr_df[col].str.split().to_list()
+                            else: 
+                                # Hetero graph and vetype already exists
+                                graph.extra_data[vetype][col] = attr_df[col].str.split().to_list()
                         elif mode == "pyg" or mode == "spektral":
                             data[col] = attr_df[col].str.split().to_list()
                     else:

--- a/tests/test_gds_BaseLoader.py
+++ b/tests/test_gds_BaseLoader.py
@@ -577,7 +577,7 @@ class TestGDSBaseLoader(unittest.TestCase):
         exit_event = Event()
         raw = (
             "People,99,1 0 0 1 ,1,0,Alex,1\nPeople,8,1 0 0 1 ,1,1,Bill,0\nCompany,2,0.3,0\n",
-            "Colleague,99,8,0.1,2021,1,0\nColleague,8,99,1.5,2020,0,1\nWork,99,2\nWork,2,8\n",
+            "Colleague,99,8,0.1,2021,1,0\nColleague,8,99,1.5,2020,0,1\nWork,99,2,a b \nWork,2,8,c d \n",
         )
         read_task_q.put(raw)
         read_task_q.put(None)
@@ -602,7 +602,7 @@ class TestGDSBaseLoader(unittest.TestCase):
             },
             {"Colleague": ["x", "time"]},
             {"Colleague": ["y"]},
-            {"Colleague": ["is_train"]},
+            {"Colleague": ["is_train"], "Work": ["category"]},
             {
                 "Colleague": {
                     "FromVertexTypeName": "People",
@@ -617,6 +617,7 @@ class TestGDSBaseLoader(unittest.TestCase):
                     "FromVertexTypeName": "People",
                     "ToVertexTypeName": "Company",
                     "IsDirected": False,
+                    "category": "LIST:STRING"
                 }
             },
             False,
@@ -640,7 +641,7 @@ class TestGDSBaseLoader(unittest.TestCase):
         assert_close_torch(data.nodes["People"].data["y"], torch.tensor([1, 1]))
         assert_close_torch(data.nodes["People"].data["train_mask"], torch.tensor([False, True]))
         assert_close_torch(data.nodes["People"].data["is_seed"], torch.tensor([True, False]))
-        self.assertListEqual(data.extra_data["name"], ["Alex", "Bill"])
+        self.assertListEqual(data.extra_data["People"]["name"], ["Alex", "Bill"])
         assert_close_torch(
             data.nodes["Company"].data["x"], torch.tensor([0.3], dtype=torch.double)
         )
@@ -648,6 +649,7 @@ class TestGDSBaseLoader(unittest.TestCase):
         assert_close_torch(
             data.edges(etype="Work"), (torch.tensor([0, 1]), torch.tensor([0, 0]))
         )
+        self.assertListEqual(data.extra_data["Work"]["category"], [['a', 'b'], ['c', 'd']])
         data = data_q.get()
         self.assertIsNone(data)
 


### PR DESCRIPTION
Issue: with the extra_data fix for DGL heterogenous graph, `None` is used as vtype key in extra_data for DGL homogeneous graph.

Fix: For DGL homogeneous graph, do not use vtype as key for extra_data.