### PR TITLE
fix(error messaging): raise TigerGraphException with error message if code != 200

### DIFF
--- a/pyTigerGraph/pyTigerGraphBase.py
+++ b/pyTigerGraph/pyTigerGraphBase.py
@@ -272,7 +272,10 @@ class pyTigerGraphBase(object):
             res = requests.request(method, url, headers=_headers, data=_data, params=params, verify=verify)
 
         if res.status_code != 200:
-            res.raise_for_status()
+            try:
+                res.raise_for_status()
+            except:
+                self._errorCheck(res)
         res = json.loads(res.text, strict=strictJson)
         if not skipCheck:
             self._errorCheck(res)


### PR DESCRIPTION
```py
>>> import pyTigerGraph as tg
>>> conn = tg.TigerGraphConnection(host="https://60db517566414cafbc6d8abb11dc7b84.i.tgcloud.io", username="user_1", password="GoGophers2022!", graphname="Ethereum")
>>> conn.runInstalledQuery("tg_pagerank", params={"v_type": "Account", "e_type": "Transaction"})
("Access Denied because the input token = '' is empty or too short", 'REST-10016')
>>> conn.getToken(conn.createSecret())
('9icv3givlpvjdehi2biu2bottqa7l2t2', 1673453616, '2023-01-11 16:13:36')
>>> conn.runInstalledQuery("tg_pagerank")
('Runtime Error: Parameter v_type is NULL.', '3001')
>>> conn.runInstalledQuery("tg_pagerank", params={"v_type": "Account", "e_type": "Transaction"})
# Correct response here
>>> conn.runInstalledQuery("tg_pr")
('Endpoint is not found from url = /query/Ethereum/tg_pr, please use GET /endpoints to list all valid endpoints.', 'REST-1000')
```