### PR TITLE
GML-1110-fix-nodepiece-cache

### DIFF
--- a/pyTigerGraph/gds/gsql/dataloaders/nodepiece_loader.gsql
+++ b/pyTigerGraph/gds/gsql/dataloaders/nodepiece_loader.gsql
@@ -33,7 +33,7 @@ CREATE QUERY nodepiece_loader_{QUERYSUFFIX}(
     SumAccum<STRING> @ancs;
 
     MapAccum<VERTEX, SumAccum<INT>> @@token_count;
-    MapAccum<INT, INT> @conv_map;
+    MapAccum<INT, MinAccum<INT>> @conv_map;
     BOOL cache_empty = FALSE;
     INT distance;
     start = {v_types};


### PR DESCRIPTION
In MapAccums<INT, INT>, += results in adding the values together if the key already exists. This led to distances that were greater than max distance.