### PR TITLE
GML-1241: fix timeout or out-of-memory issue with getVertexCount 

### DIFF
--- a/pyTigerGraph/pyTigerGraphVertex.py
+++ b/pyTigerGraph/pyTigerGraphVertex.py
@@ -166,7 +166,6 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 raise TigerGraphException(
                     "VertexType cannot be a list if where condition is specified.", None)
 
-        # TODO Investigate: /builtins/stat_vertex_number: why it is not up-to-date after insert?
         res = self._post(self.restppUrl + "/builtins/" + self.graphname,
                          data={"function": "stat_vertex_number", "type": "*"},
                          jsonData=True)

--- a/pyTigerGraph/pyTigerGraphVertex.py
+++ b/pyTigerGraph/pyTigerGraphVertex.py
@@ -108,7 +108,7 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
 
         return {}  # Vertex type was not found
 
-    def getVertexCount(self, vertexType: Union[str, list] = "*", where: str = "") -> Union[int, dict]:
+    def getVertexCount(self, vertexType: Union[str, list] = "*", where: str = "", realtime: bool = False) -> Union[int, dict]:
         """Returns the number of vertices of the specified type.
 
         Args:
@@ -119,6 +119,11 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 A comma separated list of conditions that are all applied on each vertex's
                 attributes. The conditions are in logical conjunction (i.e. they are "AND'ed"
                 together).
+            realtime (bool):
+                Whether to get the most up-to-date number by force. When there are frequent updates happening, 
+                a slightly outdated number (up to 30 seconds delay) might be fetched. Set `realtime=True` to
+                force the system to recount the vertices, which will get a more up-to-date result but will
+                also take more time.  
 
         Returns:
             A dictionary of <vertex_type>: <vertex_count> pairs.
@@ -148,7 +153,7 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 res = self._get(self.restppUrl + "/graph/" + self.graphname + "/vertices/" + vertexType
                     + "?count_only=true" + "&filter=" + where)[0]["count"]
             else:
-                res = self._post(self.restppUrl + "/builtins/" + self.graphname,
+                res = self._post(self.restppUrl + "/builtins/" + self.graphname + "?realtime=true" if realtime else "",
                                  data={"function": "stat_vertex_number", "type": vertexType},
                                  jsonData=True)[0]["count"]
 
@@ -166,7 +171,7 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 raise TigerGraphException(
                     "VertexType cannot be a list if where condition is specified.", None)
 
-        res = self._post(self.restppUrl + "/builtins/" + self.graphname,
+        res = self._post(self.restppUrl + "/builtins/" + self.graphname + "?realtime=true" if realtime else "",
                          data={"function": "stat_vertex_number", "type": "*"},
                          jsonData=True)
         ret = {d["v_type"]: d["count"] for d in res}

--- a/pyTigerGraph/pyTigerGraphVertex.py
+++ b/pyTigerGraph/pyTigerGraphVertex.py
@@ -153,7 +153,7 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 res = self._get(self.restppUrl + "/graph/" + self.graphname + "/vertices/" + vertexType
                     + "?count_only=true" + "&filter=" + where)[0]["count"]
             else:
-                res = self._post(self.restppUrl + "/builtins/" + self.graphname + "?realtime=true" if realtime else "",
+                res = self._post(self.restppUrl + "/builtins/" + self.graphname + ("?realtime=true" if realtime else ""),
                                  data={"function": "stat_vertex_number", "type": vertexType},
                                  jsonData=True)[0]["count"]
 
@@ -171,7 +171,7 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 raise TigerGraphException(
                     "VertexType cannot be a list if where condition is specified.", None)
 
-        res = self._post(self.restppUrl + "/builtins/" + self.graphname + "?realtime=true" if realtime else "",
+        res = self._post(self.restppUrl + "/builtins/" + self.graphname + ("?realtime=true" if realtime else ""),
                          data={"function": "stat_vertex_number", "type": "*"},
                          jsonData=True)
         ret = {d["v_type"]: d["count"] for d in res}

--- a/pyTigerGraph/pyTigerGraphVertex.py
+++ b/pyTigerGraph/pyTigerGraphVertex.py
@@ -123,7 +123,7 @@ class pyTigerGraphVertex(pyTigerGraphUtils, pyTigerGraphSchema):
                 Whether to get the most up-to-date number by force. When there are frequent updates happening, 
                 a slightly outdated number (up to 30 seconds delay) might be fetched. Set `realtime=True` to
                 force the system to recount the vertices, which will get a more up-to-date result but will
-                also take more time.  
+                also take more time. This parameter only works with TigerGraph DB 3.6 and above. 
 
         Returns:
             A dictionary of <vertex_type>: <vertex_count> pairs.

--- a/tests/test_pyTigerGraphVertex.py
+++ b/tests/test_pyTigerGraphVertex.py
@@ -73,8 +73,20 @@ class test_pyTigerGraphVertex(unittest.TestCase):
 
         with self.assertRaises(TigerGraphException) as tge:
             self.conn.getVertexCount("non_existing_vertex_type")
-        self.assertEqual("REST-30000", tge.exception.code)
-        # self.assertEqual("GSQL-7004", tge.exception.code)  # TODO use with /builtins/
+        # self.assertEqual("REST-30000", tge.exception.code)
+        self.assertEqual("GSQL-7004", tge.exception.code)
+
+        res = self.conn.getVertexCount("*", realtime=True)
+        self.assertIsInstance(res, dict)
+        self.assertEqual(7, len(res))
+        self.assertIn("vertex4", res)
+        self.assertEqual(5, res["vertex4"])
+        self.assertIn("vertex1_all_types", res)
+        self.assertEqual(0, res["vertex1_all_types"])
+
+        res = self.conn.getVertexCount("vertex4", realtime=True)
+        self.assertIsInstance(res, int)
+        self.assertEqual(5, res)
 
     def test_04_upsertVertex(self):
         res = self.conn.upsertVertex("vertex4", 100, {"a01": 100})


### PR DESCRIPTION
Issue
* The `/graph/{graph_name}/vertices` endpoint with `count_only=true` is too slow on large graphs and sometime it even causes GPE to crash due to OOM.

Solution
* Use `/builtins` with `stat_vertex_number` whenever possible (i.e., `where` clause is not needed).