### PR TITLE
GML-1341: data loader on a multi-node cluster is too slow

### DIFF
--- a/pyTigerGraph/gds/dataloaders.py
+++ b/pyTigerGraph/gds/dataloaders.py
@@ -540,8 +540,8 @@ class BaseLoader:
                     break
             else:
                 raise TigerGraphException(
-                    "Error generating data. Query {}.".format(
-                        status["results"][0]["status"]
+                    "Error generating data. {}".format(
+                        status
                     )
                 )
         # exiting


### PR DESCRIPTION
After close examination, a big change will be needed to fix this issue. So close this issue, but there is a small bug on error message that can be fixed quickly.  