### PR TITLE
fix(pyTigerGraphQuery): fix getQueryDescription so that it doesn't error out when getting the query results

### DIFF
--- a/pyTigerGraph/pyTigerGraphQuery.py
+++ b/pyTigerGraph/pyTigerGraphQuery.py
@@ -663,7 +663,7 @@ class pyTigerGraphQuery(pyTigerGraphUtils, pyTigerGraphSchema, pyTigerGraphGSQL)
         if not res["error"]:
             if logger.level == logging.DEBUG:
                 logger.debug("exit: getQueryDescription")
-            return res["queries"]
+            return res["results"]["queries"]
         else:
             raise TigerGraphException(res["message"], res["code"])
         


### PR DESCRIPTION
More info here: https://graphsql.atlassian.net/browse/GML-1735

There seems to be a change in the `/gsqlserver/gsql/description` endpoint so that the result format is like below:

```
{
    "error": false,
    "message": "Retrieve descriptions successfully.",
    "results": {
        "queries": [
            {
                "queryName": "card_has_frequent_transactions",
                "description": "This query identifies and retrieves all card numbers that have conducted more than k transactions within a specified time period. It is used to detect potential fraud by pinpointing cards with unusually high transaction volumes, which may suggest stolen card details being exploited or other fraudulent behaviors.",
                "parameters": [
                    {
                        "defaultValue": "1546732800",
                        "description": "The earliest time to look back in history. Defaults to 2019-01-06",
                        "paramName": "min_createTime"
                    },
                    {
                        "defaultValue": "1641600000",
                        "description": "The latest time to look back in history. Defaults to 2024-01-01",
                        "paramName": "max_createTime"
                    },
                    {
                        "defaultValue": "3000l",
                        "description": "The threshold count or frequency value for transactions . Defaults to 3000",
                        "paramName": "freq"
                    }
                ]
            }
        ]
    }
}
```