### PR TITLE
vertexMustExist

### DIFF
--- a/pyTigerGraph/pyTigerGraphEdge.py
+++ b/pyTigerGraph/pyTigerGraphEdge.py
@@ -550,7 +550,7 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
         edgeType: str,
         targetVertexType: str,
         edges: list,
-        vertexMustExist=True,
+        vertexMustExist=False,
     ) -> int:
         """Upserts multiple edges (of the same type).
 
@@ -653,9 +653,7 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
             else:
                 vals = {}
             # sourceVertexId
-            sourceVertexId = str(
-                e[0]
-            )  # Converted to string as the key in the JSON payload must be a string
+            sourceVertexId = str(e[0])  # Converted to string as the key in the JSON payload must be a string
             if sourceVertexId not in l1:
                 l1[sourceVertexId] = {}
             l2 = l1[sourceVertexId]
@@ -671,9 +669,7 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
                 l4[self.___trgvtxids] = {}
             l4 = l4[self.___trgvtxids]
             # targetVertexId
-            targetVertexId = str(
-                e[1]
-            )  # Converted to string as the key in the JSON payload must be a string
+            targetVertexId = str(e[1])  # Converted to string as the key in the JSON payload must be a string
             if targetVertexId not in l4:
                 l4[targetVertexId] = []
             l4[targetVertexId].append(vals)

--- a/pyTigerGraph/pyTigerGraphEdge.py
+++ b/pyTigerGraph/pyTigerGraphEdge.py
@@ -459,15 +459,23 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
 
         return ret
 
-    def upsertEdge(self, sourceVertexType: str, sourceVertexId: str, edgeType: str,
-            targetVertexType: str, targetVertexId: str, attributes: dict = None) -> int:
+    def upsertEdge(
+        self,
+        sourceVertexType: str,
+        sourceVertexId: str,
+        edgeType: str,
+        targetVertexType: str,
+        targetVertexId: str,
+        attributes: dict = None,
+        vertexMustExist: bool = False,
+    ) -> int:
         """Upserts an edge.
 
         Data is upserted:
 
         - If edge is not yet present in graph, it will be created (see special case below).
         - If it's already in the graph, it is updated with the values specified in the request.
-        - If `vertex_must_exist` is True then edge will only be created if both vertex exists
+        - If `vertex_must_exist` is True then edge will only be created if both vertices exists
             in graph. Otherwise missing vertices are created with the new edge; the newly created
             vertices' attributes (if any) will be created with default values.
 
@@ -511,22 +519,24 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
             attributes = {}
 
         vals = self._upsertAttrs(attributes)
-        data = json.dumps({
-            "edges": {
-                sourceVertexType: {
-                    sourceVertexId: {
-                        edgeType: {
-                            targetVertexType: {
-                                targetVertexId: vals
-                            }
+        data = json.dumps(
+            {
+                "edges": {
+                    sourceVertexType: {
+                        sourceVertexId: {
+                            edgeType: {targetVertexType: {targetVertexId: vals}}
                         }
                     }
                 }
             }
-        })
+        )
 
-        ret = self._post(self.restppUrl + "/graph/" + self.graphname, data=data)[0][
-            "accepted_edges"]
+        params = {"vertex_must_exist": vertexMustExist}
+        ret = self._post(
+            self.restppUrl + "/graph/" + self.graphname,
+            data=data,
+            params=params,
+        )[0]["accepted_edges"]
 
         if logger.level == logging.DEBUG:
             logger.debug("return: " + str(ret))
@@ -534,8 +544,14 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
 
         return ret
 
-    def upsertEdges(self, sourceVertexType: str, edgeType: str, targetVertexType: str,
-            edges: list) -> int:
+    def upsertEdges(
+        self,
+        sourceVertexType: str,
+        edgeType: str,
+        targetVertexType: str,
+        edges: list,
+        vertexMustExist=True,
+    ) -> int:
         """Upserts multiple edges (of the same type).
 
         Args:
@@ -607,11 +623,11 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
                             for v3 in v2:
                                 if c3 > 0:
                                     ret += ","
-                                ret += json.dumps(k2) + ':' + json.dumps(v3)
+                                ret += json.dumps(k2) + ":" + json.dumps(v3)
                                 c3 += 1
                             c2 += 1
                     else:
-                        ret += json.dumps(k1) + ':' + _dumps(data[k1])
+                        ret += json.dumps(k1) + ":" + _dumps(data[k1])
                     c1 += 1
             return "{" + ret + "}"
 
@@ -637,7 +653,9 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
             else:
                 vals = {}
             # sourceVertexId
-            sourceVertexId = str(e[0])  # Converted to string as the key in the JSON payload must be a string
+            sourceVertexId = str(
+                e[0]
+            )  # Converted to string as the key in the JSON payload must be a string
             if sourceVertexId not in l1:
                 l1[sourceVertexId] = {}
             l2 = l1[sourceVertexId]
@@ -653,15 +671,19 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
                 l4[self.___trgvtxids] = {}
             l4 = l4[self.___trgvtxids]
             # targetVertexId
-            targetVertexId = str(e[1])  # Converted to string as the key in the JSON payload must be a string
+            targetVertexId = str(
+                e[1]
+            )  # Converted to string as the key in the JSON payload must be a string
             if targetVertexId not in l4:
                 l4[targetVertexId] = []
             l4[targetVertexId].append(vals)
 
         data = _dumps({"edges": data})
 
-        ret = self._post(self.restppUrl + "/graph/" + self.graphname, data=data)[0][
-            "accepted_edges"]
+        params = {"vertex_must_exist": vertexMustExist}
+        ret = self._post(
+            self.restppUrl + "/graph/" + self.graphname, data=data, params=params
+        )[0]["accepted_edges"]
 
         if logger.level == logging.DEBUG:
             logger.debug("return: " + str(ret))
@@ -669,9 +691,17 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
 
         return ret
 
-    def upsertEdgeDataFrame(self, df: 'pd.DataFrame', sourceVertexType: str, edgeType: str,
-            targetVertexType: str, from_id: str = "", to_id: str = "",
-            attributes: dict = None) -> int:
+    def upsertEdgeDataFrame(
+        self,
+        df: "pd.DataFrame",
+        sourceVertexType: str,
+        edgeType: str,
+        targetVertexType: str,
+        from_id: str = "",
+        to_id: str = "",
+        attributes: dict = None,
+        vertexMustExist: bool = False,
+    ) -> int:
         """Upserts edges from a Pandas DataFrame.
 
         Args:
@@ -709,11 +739,20 @@ class pyTigerGraphEdge(pyTigerGraphQuery):
             json_up[-1] = (
                 index if from_id is None else json_up[-1][from_id],
                 index if to_id is None else json_up[-1][to_id],
-                json_up[-1] if attributes is None
-                else {target: json_up[-1][source] for target, source in attributes.items()}
+                json_up[-1]
+                if attributes is None
+                else {
+                    target: json_up[-1][source] for target, source in attributes.items()
+                },
             )
 
-        ret = self.upsertEdges(sourceVertexType, edgeType, targetVertexType, json_up)
+        ret = self.upsertEdges(
+            sourceVertexType,
+            edgeType,
+            targetVertexType,
+            json_up,
+            vertexMustExist=vertexMustExist,
+        )
 
         if logger.level == logging.DEBUG:
             logger.debug("return: " + str(ret))

--- a/tests/test_pyTigerGraphEdge.py
+++ b/tests/test_pyTigerGraphEdge.py
@@ -101,14 +101,10 @@ class test_pyTigerGraphEdge(unittest.TestCase):
     def test_06_getReverseEdge(self):
         res = self.conn.getReverseEdge("edge1_undirected")
         self.assertIsInstance(res, str)
-        self.assertEqual(
-            "", res
-        )  # TODO Change this to None or something in getReverseEdge()?
+        self.assertEqual("", res)  # TODO Change this to None or something in getReverseEdge()?
         res = self.conn.getReverseEdge("edge2_directed")
         self.assertIsInstance(res, str)
-        self.assertEqual(
-            "", res
-        )  # TODO Change this to None or something in getReverseEdge()?
+        self.assertEqual("", res)  # TODO Change this to None or something in getReverseEdge()?
         res = self.conn.getReverseEdge("edge3_directed_with_reverse")
         self.assertIsInstance(res, str)
         self.assertEqual("edge3_directed_with_reverse_reverse_edge", res)

--- a/tests/test_pyTigerGraphEdge.py
+++ b/tests/test_pyTigerGraphEdge.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-import pandas
+import pandas as pd
 from pyTigerGraphUnitTest import make_connection
 
 
@@ -13,8 +13,14 @@ class test_pyTigerGraphEdge(unittest.TestCase):
     def test_01_getEdgeTypes(self):
         res = sorted(self.conn.getEdgeTypes())
         self.assertEqual(6, len(res))
-        exp = ["edge1_undirected", "edge2_directed", "edge3_directed_with_reverse",
-            "edge4_many_to_many", "edge5_all_to_all", "edge6_loop"]
+        exp = [
+            "edge1_undirected",
+            "edge2_directed",
+            "edge3_directed_with_reverse",
+            "edge4_many_to_many",
+            "edge5_all_to_all",
+            "edge6_loop",
+        ]
         self.assertEqual(exp, res)
 
     def test_02_getEdgeType(self):
@@ -44,7 +50,9 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertTrue(res["IsDirected"])
         self.assertIn("Config", res)
         self.assertIn("REVERSE_EDGE", res["Config"])
-        self.assertEqual("edge3_directed_with_reverse_reverse_edge", res["Config"]["REVERSE_EDGE"])
+        self.assertEqual(
+            "edge3_directed_with_reverse_reverse_edge", res["Config"]["REVERSE_EDGE"]
+        )
 
         res = self.conn.getEdgeType("edge4_many_to_many")
         self.assertIsNotNone(res)
@@ -93,10 +101,14 @@ class test_pyTigerGraphEdge(unittest.TestCase):
     def test_06_getReverseEdge(self):
         res = self.conn.getReverseEdge("edge1_undirected")
         self.assertIsInstance(res, str)
-        self.assertEqual("", res)  # TODO Change this to None or something in getReverseEdge()?
+        self.assertEqual(
+            "", res
+        )  # TODO Change this to None or something in getReverseEdge()?
         res = self.conn.getReverseEdge("edge2_directed")
         self.assertIsInstance(res, str)
-        self.assertEqual("", res)  # TODO Change this to None or something in getReverseEdge()?
+        self.assertEqual(
+            "", res
+        )  # TODO Change this to None or something in getReverseEdge()?
         res = self.conn.getReverseEdge("edge3_directed_with_reverse")
         self.assertIsInstance(res, str)
         self.assertEqual("edge3_directed_with_reverse_reverse_edge", res)
@@ -113,8 +125,11 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertIsInstance(res, int)
         self.assertEqual(8, res)
 
-        res = self.conn.getEdgeCountFrom(sourceVertexType="vertex4", edgeType="edge4_many_to_many",
-            targetVertexType="vertex5")
+        res = self.conn.getEdgeCountFrom(
+            sourceVertexType="vertex4",
+            edgeType="edge4_many_to_many",
+            targetVertexType="vertex5",
+        )
         self.assertIsInstance(res, int)
         self.assertEqual(3, res)
 
@@ -125,25 +140,39 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertIn("edge2_directed", res)
         self.assertEqual(0, res["edge2_directed"])
         self.assertIn("edge4_many_to_many", res)
-        self.assertEqual(3, res["edge1_undirected"])
+        self.assertEqual(3, res["edge4_many_to_many"])
 
-        res = self.conn.getEdgeCountFrom(sourceVertexType="vertex4", sourceVertexId=1,
-            edgeType="edge1_undirected")
+        res = self.conn.getEdgeCountFrom(
+            sourceVertexType="vertex4", sourceVertexId=1, edgeType="edge1_undirected"
+        )
         self.assertIsInstance(res, int)
         self.assertEqual(3, res)
 
-        res = self.conn.getEdgeCountFrom(sourceVertexType="vertex4", sourceVertexId=1,
-            edgeType="edge1_undirected", where="a01=2")
+        res = self.conn.getEdgeCountFrom(
+            sourceVertexType="vertex4",
+            sourceVertexId=1,
+            edgeType="edge1_undirected",
+            where="a01=2",
+        )
         self.assertIsInstance(res, int)
         self.assertEqual(2, res)
 
-        res = self.conn.getEdgeCountFrom(sourceVertexType="vertex4", sourceVertexId=1,
-            edgeType="edge1_undirected", targetVertexType="vertex5")
+        res = self.conn.getEdgeCountFrom(
+            sourceVertexType="vertex4",
+            sourceVertexId=1,
+            edgeType="edge1_undirected",
+            targetVertexType="vertex5",
+        )
         self.assertIsInstance(res, int)
         self.assertEqual(3, res)
 
-        res = self.conn.getEdgeCountFrom(sourceVertexType="vertex4", sourceVertexId=1,
-            edgeType="edge1_undirected", targetVertexType="vertex5", targetVertexId=3)
+        res = self.conn.getEdgeCountFrom(
+            sourceVertexType="vertex4",
+            sourceVertexId=1,
+            edgeType="edge1_undirected",
+            targetVertexType="vertex5",
+            targetVertexId=3,
+        )
         self.assertIsInstance(res, int)
         self.assertEqual(1, res)
 
@@ -202,13 +231,35 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         #   atomic_level parameters; when they will be added to pyTigerGraphEdge.upsertEdge()
         # TODO Add MultiEdge edge to schema and add test cases
 
+    def test_09_upsertEdge_mustExist(self):
+        res = self.conn.upsertEdge(
+            "vertex6",
+            int(1e6),
+            "edge4_many_to_many",
+            "vertex7",
+            1,
+            vertexMustExist=True,
+        )
+        self.assertIsInstance(res, int)
+        self.assertEqual(0, res)
+
+        res = self.conn.upsertEdge(
+            "vertex6",
+            6,
+            "edge4_many_to_many",
+            "vertex7",
+            int(2e6),
+            vertexMustExist=True,
+        )
+        self.assertIsInstance(res, int)
+        self.assertEqual(0, res)
+
+        # TODO Tests with ack, new_vertex_only, vertex_must_exist, update_vertex_only and
+        #   atomic_level parameters; when they will be added to pyTigerGraphEdge.upsertEdge()
+        # TODO Add MultiEdge edge to schema and add test cases
+
     def test_10_upsertEdges(self):
-        es = [
-            (2, 1),
-            (2, 2),
-            (2, 3),
-            (2, 4)
-        ]
+        es = [(2, 1), (2, 2), (2, 3), (2, 4)]
         res = self.conn.upsertEdges("vertex6", "edge4_many_to_many", "vertex7", es)
         self.assertIsInstance(res, int)
         self.assertEqual(4, res)
@@ -217,28 +268,104 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertIsInstance(res, int)
         self.assertEqual(14, res)
 
+    def test_10_upsertEdges_mustExist(self):
+        es = [(2, int(1e6)), (int(1e6), 2)]
+        res = self.conn.upsertEdges(
+            "vertex6", "edge4_many_to_many", "vertex7", es, vertexMustExist=True
+        )
+        self.assertIsInstance(res, int)
+        self.assertEqual(0, res)
+
     def test_11_upsertEdgeDataFrame(self):
-        # TODO Implement
-        pass
+        edges = [
+            {
+                "e_type": "edge1_undirected",
+                "directed": False,
+                "from_id": 1,
+                "from_type": "vertex4",
+                "to_id": 4,
+                "to_type": "vertex5",
+                "attributes": {"a01": -100},
+            },
+            {
+                "e_type": "edge1_undirected",
+                "directed": False,
+                "from_id": 1,
+                "from_type": "vertex4",
+                "to_id": 5,
+                "to_type": "vertex5",
+                "attributes": {"a01": -100},
+            },
+        ]
+        df = self.conn.edgeSetToDataFrame(edges)
+        res = self.conn.upsertEdgeDataFrame(
+            df=df,
+            sourceVertexType="vertex4",
+            edgeType="edge1_undirected",
+            targetVertexType="vertex5",
+            from_id="from_id",
+            to_id="to_id",
+            attributes={"a01": "a01"},
+            vertexMustExist=True,
+        )
+        self.assertIsInstance(res, int)
+        self.assertEqual(2, res)
+
+    def test_11_upsertEdgeDataFrame_vertexMustExist(self):
+        edges = [
+            {
+                "e_type": "edge1_undirected",
+                "directed": False,
+                "from_id": -1,
+                "from_type": "vertex4",
+                "to_id": 4,
+                "to_type": "vertex5",
+                "attributes": {"a01": -100},
+            },
+            {
+                "e_type": "edge1_undirected",
+                "directed": False,
+                "from_id": 1,
+                "from_type": "vertex4",
+                "to_id": -5,
+                "to_type": "vertex5",
+                "attributes": {"a01": -100},
+            },
+        ]
+        df = self.conn.edgeSetToDataFrame(edges)
+        res = self.conn.upsertEdgeDataFrame(
+            df=df,
+            sourceVertexType="vertex4",
+            edgeType="edge1_undirected",
+            targetVertexType="vertex5",
+            from_id="from_id",
+            to_id="to_id",
+            attributes={"a01": "a01"},
+            vertexMustExist=True,
+        )
+        self.assertIsInstance(res, int)
+        self.assertEqual(0, res)
 
     def test_12_getEdges(self):
         res = self.conn.getEdges("vertex4", 1)
         self.assertIsInstance(res, list)
-        self.assertEqual(6, len(res))
+        self.assertEqual(8, len(res))
 
         res = self.conn.getEdges("vertex4", 1, "edge1_undirected")
         self.assertIsInstance(res, list)
-        self.assertEqual(3, len(res))
+        self.assertEqual(5, len(res))
 
         res = self.conn.getEdges("vertex4", 1, "edge1_undirected", "vertex5")
         self.assertIsInstance(res, list)
-        self.assertEqual(3, len(res))
+        self.assertEqual(5, len(res))
 
         res = self.conn.getEdges("vertex4", 1, "edge1_undirected", "vertex5", 2)
         self.assertIsInstance(res, list)
         self.assertEqual(1, len(res))
 
-        res = self.conn.getEdges("vertex4", 1, "edge1_undirected", select="a01", where="a01>1")
+        res = self.conn.getEdges(
+            "vertex4", 1, "edge1_undirected", select="a01", where="a01>1"
+        )
         self.assertIsInstance(res, list)
         self.assertEqual(2, len(res))
 
@@ -246,25 +373,27 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertIsInstance(res, list)
         self.assertEqual(2, len(res))
 
-        res = self.conn.getEdges("vertex4", 1, "edge1_undirected", "vertex5", fmt="json")
+        res = self.conn.getEdges(
+            "vertex4", 1, "edge1_undirected", "vertex5", fmt="json"
+        )
         self.assertIsInstance(res, str)
         res = json.loads(res)
         self.assertIsInstance(res, list)
-        self.assertEqual(3, len(res))
+        self.assertEqual(5, len(res))
 
         res = self.conn.getEdges("vertex4", 1, "edge1_undirected", "vertex5", fmt="df")
-        self.assertIsInstance(res, pandas.DataFrame)
-        self.assertEqual(3, len(res.index))
+        self.assertIsInstance(res, pd.DataFrame)
+        self.assertEqual(5, len(res.index))
 
     def test_13_getEdgesDataFrame(self):
         res = self.conn.getEdgesDataFrame("vertex4", 1, "edge1_undirected", "vertex5")
-        self.assertIsInstance(res, pandas.DataFrame)
-        self.assertEqual(3, len(res.index))
+        self.assertIsInstance(res, pd.DataFrame)
+        self.assertEqual(5, len(res.index))
 
     def test_14_getEdgesByType(self):
         res = self.conn.getEdgesByType("edge1_undirected")
         self.assertIsInstance(res, list)
-        self.assertEqual(8, len(res))
+        self.assertEqual(10, len(res))
 
     def test_15_getEdgesDataFrameByType(self):
         pass
@@ -275,9 +404,11 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertEqual(1, len(res))
         self.assertIn("edge1_undirected", res)
         self.assertEqual(2, res["edge1_undirected"]["a01"]["MAX"])
-        self.assertEqual(1.875, res["edge1_undirected"]["a01"]["AVG"])
+        self.assertEqual(-18.5, res["edge1_undirected"]["a01"]["AVG"])
 
-        res = self.conn.getEdgeStats(["edge1_undirected", "edge2_directed", "edge6_loop"])
+        res = self.conn.getEdgeStats(
+            ["edge1_undirected", "edge2_directed", "edge6_loop"]
+        )
         self.assertIsInstance(res, dict)
         self.assertEqual(3, len(res))
         self.assertIn("edge1_undirected", res)
@@ -287,8 +418,9 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         self.assertIn("edge6_loop", res)
         self.assertEqual({}, res["edge6_loop"])
 
-        res = self.conn.getEdgeStats(["edge1_undirected", "edge2_directed", "edge6_loop"],
-            skipNA=True)
+        res = self.conn.getEdgeStats(
+            ["edge1_undirected", "edge2_directed", "edge6_loop"], skipNA=True
+        )
         self.assertIsInstance(res, dict)
         self.assertEqual(2, len(res))
         self.assertIn("edge1_undirected", res)
@@ -336,5 +468,5 @@ class test_pyTigerGraphEdge(unittest.TestCase):
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[GML-1436](https://graphsql.atlassian.net/browse/GML-1436)

Some changes are just the [ruff formatter](https://docs.astral.sh/ruff/formatter/#:~:text=The%20Ruff%20formatter%20is%20an,1.2.)

Changes include adding the `vertexMustExist` param to `upsertEdge`, `upsertEdges`, and `upsertEdgeDataFrame`. It defaults to False.

[GML-1436]: https://graphsql.atlassian.net/browse/GML-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ