### PR TITLE
GML-2077 Release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-04-09
+
+### Fixed
+
+- **Host URL port extraction** — when the host URL contains a port (e.g. `http://192.168.11.11:14240`), it is now correctly extracted and used instead of producing malformed double-port URLs. Conflicts with explicitly provided `restppPort`/`gsPort` are detected and reported.
+- **PEP 639 license compliance** — removed the deprecated `License ::` classifier that conflicts with the `license = "Apache-2.0"` expression, fixing build failures with newer setuptools.
+
+---
+
 ## [2.0.2] - 2026-04-07
 
 ### New Features
@@ -35,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`dropAllDataSources()`** now correctly uses `self.graphname` fallback for the 4.x REST API path.
 - **`getVectorIndexStatus()`** no longer produces a malformed URL when called without a graph name; now supports global scope (returns status for all graphs).
 - **`previewSampleData()`** now raises `TigerGraphException` when no graph name is available, instead of sending an empty graph name to the server.
+- **Host URL port extraction** — when the host URL contains a port (e.g. `http://192.168.11.11:14240`), it is now correctly extracted and used instead of producing malformed double-port URLs. Conflicts with explicitly provided `restppPort`/`gsPort` are detected and reported.
 - **Docstring fixes** — corrected `timeout` parameter descriptions across vertex and edge query methods.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.3] - 2026-04-09
 
+### New Features
+
+- **`dropGraph()` cascade parameter** — `dropGraph(graphName, cascade=True)` automatically removes associated queries and loading jobs. Uses the REST API on TigerGraph >= 4.0 and GSQL `DROP GRAPH ... CASCADE` on older versions.
+
 ### Fixed
 
-- **Host URL port extraction** — when the host URL contains a port (e.g. `http://192.168.11.11:14240`), it is now correctly extracted and used instead of producing malformed double-port URLs. Conflicts with explicitly provided `restppPort`/`gsPort` are detected and reported.
+- **Host URL port extraction** — when the host URL contains a port (e.g. `http://127.0.0.1:14240`), it is now correctly extracted and used instead of producing malformed double-port URLs. Conflicts with explicitly provided `restppPort`/`gsPort` are detected and reported.
+- **Host URL validation** — malformed or empty hostnames and out-of-range ports now raise `TigerGraphException` instead of crashing with an uncaught error.
+- **HTTP timeout during large file uploads** — the connect timeout no longer stays on the socket during POST body transmission; both connect and read now use a single timeout value derived from `GSQL-TIMEOUT`.
+- **Header merge order** — per-request headers (e.g. `timeout` passed to `runLoadingJobWithFile()`) now correctly override `responseConfigHeader` set by `customizeHeader()`.
+- **Loading job default timeout** — changed from 16000ms to 0 (use server-wide timeout) for `runLoadingJobWithFile()`, `runLoadingJobWithData()`, `runLoadingJobWithDataFrame()`, and `uploadFile()`.
 - **PEP 639 license compliance** — removed the deprecated `License ::` classifier that conflicts with the `license = "Apache-2.0"` expression, fixing build failures with newer setuptools.
 
 ---
@@ -44,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`dropAllDataSources()`** now correctly uses `self.graphname` fallback for the 4.x REST API path.
 - **`getVectorIndexStatus()`** no longer produces a malformed URL when called without a graph name; now supports global scope (returns status for all graphs).
 - **`previewSampleData()`** now raises `TigerGraphException` when no graph name is available, instead of sending an empty graph name to the server.
-- **Host URL port extraction** — when the host URL contains a port (e.g. `http://192.168.11.11:14240`), it is now correctly extracted and used instead of producing malformed double-port URLs. Conflicts with explicitly provided `restppPort`/`gsPort` are detected and reported.
+- **Host URL port extraction** — when the host URL contains a port (e.g. `http://127.0.0.1:14240`), it is now correctly extracted and used instead of producing malformed double-port URLs. Conflicts with explicitly provided `restppPort`/`gsPort` are detected and reported.
 - **Docstring fixes** — corrected `timeout` parameter descriptions across vertex and edge query methods.
 
 ---

--- a/build.sh
+++ b/build.sh
@@ -76,32 +76,6 @@ if $DO_UPLOAD; then
 
     echo "---- Uploading to PyPI ----"
     python3 -m twine upload dist/*
-
-    # Update conda recipe meta.yaml with the new version and sha256
-    PKG_VERSION=$(grep "^version" pyproject.toml | awk -F'"' '{print $2}')
-    TARBALL_URL="https://pypi.org/packages/source/p/$PYPI_PACKAGE/$PYPI_PACKAGE-$PKG_VERSION.tar.gz"
-
-    echo "---- Updating conda recipe to $PKG_VERSION ----"
-    # Wait briefly for PyPI to make the tarball available
-    for i in $(seq 1 30); do
-        HTTP_CODE=$(curl -sL -o /dev/null -w "%{http_code}" "$TARBALL_URL")
-        if [[ "$HTTP_CODE" == "200" ]]; then
-            break
-        fi
-        echo "  Waiting for PyPI tarball to become available... ($i/30)"
-        sleep 5
-    done
-    if [[ "$HTTP_CODE" != "200" ]]; then
-        echo "Warning: could not fetch tarball from PyPI. Update meta.yaml manually." >&2
-    else
-        NEW_SHA=$(curl -sL "$TARBALL_URL" | sha256sum | awk '{print $1}')
-        sed -i.bak "s|^  version:.*|  version: \"$PKG_VERSION\"|" "$RECIPE_DIR/meta.yaml"
-        sed -i.bak "s|^  url:.*|  url: $TARBALL_URL|" "$RECIPE_DIR/meta.yaml"
-        sed -i.bak "s|^  sha256:.*|  sha256: $NEW_SHA|" "$RECIPE_DIR/meta.yaml"
-        sed -i.bak "s|^  # sha256:.*|  sha256: $NEW_SHA|" "$RECIPE_DIR/meta.yaml"
-        rm -f "$RECIPE_DIR/meta.yaml.bak"
-        echo "  ✓ Updated meta.yaml: version=$PKG_VERSION sha256=$NEW_SHA"
-    fi
 fi
 
 # ── Conda ───────────────────────────────────────────────────────────────────
@@ -113,7 +87,7 @@ if $DO_CONDA_BUILD; then
     fi
 
     # Verify the required version is already published on PyPI before proceeding.
-    RECIPE_VERSION=$(grep "^  version:" "$RECIPE_DIR/meta.yaml" | awk '{print $2}' | tr -d '"')
+    RECIPE_VERSION=$(grep '{%\s*set\s*version' "$RECIPE_DIR/meta.yaml" | sed 's/.*"\(.*\)".*/\1/')
     echo "---- Checking PyPI for $PYPI_PACKAGE==$RECIPE_VERSION ----"
     PYPI_VERSIONS=$(curl -sf "https://pypi.org/pypi/$PYPI_PACKAGE/json" | python3 -c "import sys,json; print('\n'.join(json.load(sys.stdin)['releases'].keys()))" 2>/dev/null || true)
     if ! echo "$PYPI_VERSIONS" | grep -qx "$RECIPE_VERSION"; then
@@ -126,21 +100,14 @@ if $DO_CONDA_BUILD; then
         echo "  ✓ Found $PYPI_PACKAGE==$RECIPE_VERSION on PyPI"
     fi
 
-    # Compute sha256 of the tarball declared in the recipe and verify it matches.
-    TARBALL_URL=$(grep "url:" "$RECIPE_DIR/meta.yaml" | awk '{print $2}')
-    echo "---- Computing sha256 for $TARBALL_URL ----"
+    # Fetch sha256 from PyPI and update the recipe.
+    TARBALL_URL=$(grep "url:" "$RECIPE_DIR/meta.yaml" | sed 's/.*url:[[:space:]]*//' | sed "s/{{[^}]*}}/$RECIPE_VERSION/g")
+    echo "---- Fetching sha256 for $TARBALL_URL ----"
     COMPUTED_SHA=$(curl -sL "$TARBALL_URL" | sha256sum | awk '{print $1}')
-    RECIPE_SHA=$(grep "sha256:" "$RECIPE_DIR/meta.yaml" | awk '{print $2}' || true)
-    if [[ -n "$RECIPE_SHA" && "$COMPUTED_SHA" != "$RECIPE_SHA" ]]; then
-        echo "Error: sha256 mismatch!" >&2
-        echo "  recipe : $RECIPE_SHA" >&2
-        echo "  actual : $COMPUTED_SHA" >&2
-        exit 1
-    fi
-    if [[ -z "$RECIPE_SHA" ]]; then
-        echo "Warning: no sha256 in recipe. For conda-forge submission add:"
-        echo "  sha256: $COMPUTED_SHA"
-    fi
+    sed -i.bak "s|^  sha256:.*|  sha256: $COMPUTED_SHA|" "$RECIPE_DIR/meta.yaml"
+    sed -i.bak "s|^  # sha256:.*|  sha256: $COMPUTED_SHA|" "$RECIPE_DIR/meta.yaml"
+    rm -f "$RECIPE_DIR/meta.yaml.bak"
+    echo "  Updated meta.yaml sha256: $COMPUTED_SHA"
 
     echo "---- Building conda package ----"
     conda build -c conda-forge "$RECIPE_DIR"

--- a/pyTigerGraph/common/base.py
+++ b/pyTigerGraph/common/base.py
@@ -47,8 +47,8 @@ logger = logging.getLogger(__name__)
 class PyTigerGraphCore(object):
     def __init__(self, host: str = "http://127.0.0.1", graphname: str = "",
                  gsqlSecret: str = "", username: str = "tigergraph", password: str = "tigergraph",
-                 tgCloud: bool = False, restppPort: Union[int, str] = "9000",
-                 gsPort: Union[int, str] = "14240", gsqlVersion: str = "", version: str = "",
+                 tgCloud: bool = False, restppPort: Union[int, str] = None,
+                 gsPort: Union[int, str] = None, gsqlVersion: str = "", version: str = "",
                  apiToken: str = "", useCert: bool = None, certPath: str = None, debug: bool = None,
                  sslPort: Union[int, str] = "443", gcp: bool = False, jwtToken: str = ""):
         """Initiate a connection object.
@@ -105,8 +105,43 @@ class PyTigerGraphCore(object):
         if inputHost.scheme not in ["http", "https"]:
             raise TigerGraphException("Invalid URL scheme. Supported schemes are http and https.",
                                       "E-0003")
-        self.netloc = inputHost.netloc
-        self.host = "{0}://{1}".format(inputHost.scheme, self.netloc)
+        # Extract port from URL if present (e.g. http://192.168.11.11:14240)
+        # Use hostname (without port) to avoid double-port URLs later.
+        hostOnly = inputHost.hostname
+        hostPort = inputHost.port  # int or None
+        if hostPort is not None:
+            _hp = str(hostPort)
+            _restpp_explicit = restppPort is not None
+            _gs_explicit = gsPort is not None
+            if _restpp_explicit and _gs_explicit:
+                # Both ports explicitly provided — URL port must match one.
+                if str(restppPort) != _hp and str(gsPort) != _hp:
+                    raise TigerGraphException(
+                        "Port {0} in host URL conflicts with restppPort={1} and gsPort={2}. "
+                        "The URL port must match restppPort or gsPort when both are specified."
+                        .format(hostPort, restppPort, gsPort), "E-0003")
+            elif _restpp_explicit and str(restppPort) != _hp:
+                raise TigerGraphException(
+                    "Port {0} in host URL conflicts with restppPort={1}. "
+                    "Specify the port in the URL or via restppPort, not both."
+                    .format(hostPort, restppPort), "E-0003")
+            elif _gs_explicit and str(gsPort) != _hp:
+                raise TigerGraphException(
+                    "Port {0} in host URL conflicts with gsPort={1}. "
+                    "Specify the port in the URL or via gsPort, not both."
+                    .format(hostPort, gsPort), "E-0003")
+            # Fill in non-explicit ports from URL port
+            if not _restpp_explicit:
+                restppPort = _hp
+            if not _gs_explicit:
+                gsPort = _hp
+        # Apply defaults for any ports still unset
+        if restppPort is None:
+            restppPort = "9000"
+        if gsPort is None:
+            gsPort = "14240"
+        self.netloc = hostOnly
+        self.host = "{0}://{1}".format(inputHost.scheme, hostOnly)
         if gsqlSecret != "":
             self.username = "__GSQL__secret"
             self.password = gsqlSecret

--- a/pyTigerGraph/common/base.py
+++ b/pyTigerGraph/common/base.py
@@ -108,7 +108,14 @@ class PyTigerGraphCore(object):
         # Extract port from URL if present (e.g. http://192.168.11.11:14240)
         # Use hostname (without port) to avoid double-port URLs later.
         hostOnly = inputHost.hostname
-        hostPort = inputHost.port  # int or None
+        if not hostOnly:
+            raise TigerGraphException(
+                "Invalid or empty hostname in host URL: " + host)
+        try:
+            hostPort = inputHost.port  # int or None
+        except ValueError:
+            raise TigerGraphException(
+                "Invalid port in host URL: " + host)
         if hostPort is not None:
             _hp = str(hostPort)
             _restpp_explicit = restppPort is not None

--- a/pyTigerGraph/common/base.py
+++ b/pyTigerGraph/common/base.py
@@ -420,14 +420,14 @@ class PyTigerGraphCore(object):
         # _refresh_auth_headers() keeps these current after every getToken() call.
         _headers = dict(self._cached_auth)
 
+        if self.responseConfigHeader:
+            _headers.update(self.responseConfigHeader)
         if headers:
             _headers.update(headers)
         if self.awsIamHeaders:
             # version >=4.1 has removed /gsqlserver/
             if url.startswith(self.gsUrl + "/gsqlserver/") or (self._versionGreaterThan4_0() and url.startswith(self.gsUrl)):
                 _headers.update(self.awsIamHeaders)
-        if self.responseConfigHeader:
-            _headers.update(self.responseConfigHeader)
         if method == "POST" or method == "PUT" or method == "DELETE":
             _data = data
         else:

--- a/pyTigerGraph/pyTigerGraph.py
+++ b/pyTigerGraph/pyTigerGraph.py
@@ -28,8 +28,8 @@ class TigerGraphConnection(pyTigerGraphVertex, pyTigerGraphEdge, pyTigerGraphUDT
 
     def __init__(self, host: str = "http://127.0.0.1", graphname: str = "",
                  gsqlSecret: str = "", username: str = "tigergraph", password: str = "tigergraph",
-                 tgCloud: bool = False, restppPort: Union[int, str] = "9000",
-                 gsPort: Union[int, str] = "14240", gsqlVersion: str = "", version: str = "",
+                 tgCloud: bool = False, restppPort: Union[int, str] = None,
+                 gsPort: Union[int, str] = None, gsqlVersion: str = "", version: str = "",
                  apiToken: str = "", useCert: bool = None, certPath: str = None, debug: bool = None,
                  sslPort: Union[int, str] = "443", gcp: bool = False, jwtToken: str = ""):
         super().__init__(host, graphname, gsqlSecret, username, password, tgCloud, restppPort,

--- a/pyTigerGraph/pyTigerGraphBase.py
+++ b/pyTigerGraph/pyTigerGraphBase.py
@@ -209,10 +209,10 @@ class pyTigerGraphBase(PyTigerGraphCore, object):
         """
         _headers, _data, _ = self._prep_req(authMode, headers, url, method, data)
 
-        if "GSQL-TIMEOUT" in _headers:
-            http_timeout = (30, int(int(_headers["GSQL-TIMEOUT"])/1000) + 30)
+        if "GSQL-TIMEOUT" in _headers and int(_headers["GSQL-TIMEOUT"]) > 0:
+            http_timeout = int(int(_headers["GSQL-TIMEOUT"])/1000) + 30
         else:
-            http_timeout = (30, None)
+            http_timeout = None
 
         conn_err = None
         try:

--- a/pyTigerGraph/pyTigerGraphBase.py
+++ b/pyTigerGraph/pyTigerGraphBase.py
@@ -54,8 +54,8 @@ logger = logging.getLogger(__name__)
 class pyTigerGraphBase(PyTigerGraphCore, object):
     def __init__(self, host: str = "http://127.0.0.1", graphname: str = "MyGraph",
                  gsqlSecret: str = "", username: str = "tigergraph", password: str = "tigergraph",
-                 tgCloud: bool = False, restppPort: Union[int, str] = "9000",
-                 gsPort: Union[int, str] = "14240", gsqlVersion: str = "", version: str = "",
+                 tgCloud: bool = False, restppPort: Union[int, str] = None,
+                 gsPort: Union[int, str] = None, gsqlVersion: str = "", version: str = "",
                  apiToken: str = "", useCert: bool = None, certPath: str = None, debug: bool = None,
                  sslPort: Union[int, str] = "443", gcp: bool = False, jwtToken: str = ""):
         """Initiate a connection object.

--- a/pyTigerGraph/pyTigerGraphLoading.py
+++ b/pyTigerGraph/pyTigerGraphLoading.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 class pyTigerGraphLoading(pyTigerGraphBase):
 
     def runLoadingJobWithDataFrame(self, df: 'pd.DataFrame', fileTag: str, jobName: str, sep: str = None,
-                                   eol: str = None, timeout: int = 16000, sizeLimit: int = 128000000, columns: list = None) -> Union[dict, None]:
+                                   eol: str = None, timeout: int = 0, sizeLimit: int = 128000000, columns: list = None) -> Union[dict, None]:
         """Execute a loading job with the given pandas DataFrame with optional column list.
 
         The data string will be posted to the TigerGraph server and the value of the appropriate
@@ -87,7 +87,7 @@ class pyTigerGraphLoading(pyTigerGraphBase):
         return res
 
     def runLoadingJobWithFile(self, filePath: str, fileTag: str, jobName: str, sep: str = None,
-                              eol: str = None, timeout: int = 16000, sizeLimit: int = 128000000) -> Union[dict, None]:
+                              eol: str = None, timeout: int = 0, sizeLimit: int = 128000000) -> Union[dict, None]:
         """Execute a loading job with the referenced file.
 
         The file will first be uploaded to the TigerGraph server and the value of the appropriate
@@ -130,7 +130,7 @@ class pyTigerGraphLoading(pyTigerGraphBase):
         return res
 
     def runLoadingJobWithData(self, data: str, fileTag: str, jobName: str, sep: str = None,
-                              eol: str = None, timeout: int = 16000, sizeLimit: int = 128000000) -> Union[dict, None]:
+                              eol: str = None, timeout: int = 0, sizeLimit: int = 128000000) -> Union[dict, None]:
         """Execute a loading job with the given data string.
 
         The data string will be posted to the TigerGraph server and the value of the appropriate
@@ -193,7 +193,7 @@ class pyTigerGraphLoading(pyTigerGraphBase):
 
         return res
 
-    def uploadFile(self, filePath, fileTag, jobName="", sep=None, eol=None, timeout=16000,
+    def uploadFile(self, filePath, fileTag, jobName="", sep=None, eol=None, timeout=0,
                    sizeLimit=128000000) -> dict:
         """DEPRECATED
 

--- a/pyTigerGraph/pyTigerGraphSchema.py
+++ b/pyTigerGraph/pyTigerGraphSchema.py
@@ -540,12 +540,16 @@ class pyTigerGraphSchema(pyTigerGraphBase):
 
         return res
 
-    def dropGraph(self, graphName: str) -> dict:
+    def dropGraph(self, graphName: str, cascade: bool = False) -> dict:
         """Drops a graph and all its data.
 
         Args:
             graphName:
                 Name of the graph to drop.
+            cascade:
+                When True, automatically removes associated queries and loading jobs.
+                When False (default), the operation fails if related queries or loading
+                jobs exist. Only supported on TigerGraph >= 4.0.
 
         Returns:
             A dict with at least a ``"message"`` key describing the outcome.
@@ -557,12 +561,15 @@ class pyTigerGraphSchema(pyTigerGraphBase):
         logger.debug("entry: dropGraph")
 
         if self._version_greater_than_4_0():
+            params = {"cascade": str(cascade).lower()} if cascade else None
             res = self._delete(self.gsUrl + "/gsql/v1/schema/graphs/" + graphName,
-                              authMode="pwd", resKey=None,
+                              authMode="pwd", resKey=None, params=params,
                               headers={'Content-Type': 'application/json'})
         else:
-            res = _wrap_gsql_result(
-                self.gsql(f"DROP GRAPH {graphName}"))
+            cmd = f"DROP GRAPH {graphName}"
+            if cascade:
+                cmd += " CASCADE"
+            res = _wrap_gsql_result(self.gsql(cmd))
 
         if logger.level == logging.DEBUG:
             logger.debug("return: " + str(res))

--- a/pyTigerGraph/pyTigerGraphSchema.py
+++ b/pyTigerGraph/pyTigerGraphSchema.py
@@ -549,7 +549,7 @@ class pyTigerGraphSchema(pyTigerGraphBase):
             cascade:
                 When True, automatically removes associated queries and loading jobs.
                 When False (default), the operation fails if related queries or loading
-                jobs exist. Only supported on TigerGraph >= 4.0.
+                jobs exist.
 
         Returns:
             A dict with at least a ``"message"`` key describing the outcome.

--- a/pyTigerGraph/pytgasync/pyTigerGraph.py
+++ b/pyTigerGraph/pytgasync/pyTigerGraph.py
@@ -29,8 +29,8 @@ class AsyncTigerGraphConnection(AsyncPyTigerGraphVertex, AsyncPyTigerGraphEdge, 
 
     def __init__(self, host: str = "http://127.0.0.1", graphname: str = "",
                  gsqlSecret: str = "", username: str = "tigergraph", password: str = "tigergraph",
-                 tgCloud: bool = False, restppPort: Union[int, str] = "9000",
-                 gsPort: Union[int, str] = "14240", gsqlVersion: str = "", version: str = "",
+                 tgCloud: bool = False, restppPort: Union[int, str] = None,
+                 gsPort: Union[int, str] = None, gsqlVersion: str = "", version: str = "",
                  apiToken: str = "", useCert: bool = None, certPath: str = None, debug: bool = None,
                  sslPort: Union[int, str] = "443", gcp: bool = False, jwtToken: str = ""):
         super().__init__(host, graphname, gsqlSecret, username, password, tgCloud, restppPort,

--- a/pyTigerGraph/pytgasync/pyTigerGraphBase.py
+++ b/pyTigerGraph/pytgasync/pyTigerGraphBase.py
@@ -148,13 +148,11 @@ class AsyncPyTigerGraphBase(PyTigerGraphCore):
 
         _headers, _data, _ = self._prep_req(authMode, headers, url, method, data)
 
-        if "GSQL-TIMEOUT" in _headers:
-            http_timeout = aiohttp.ClientTimeout(
-                sock_connect=30,
-                total=int(int(_headers["GSQL-TIMEOUT"]) / 1000) + 30,
-            )
+        if "GSQL-TIMEOUT" in _headers and int(_headers["GSQL-TIMEOUT"]) > 0:
+            _total = int(int(_headers["GSQL-TIMEOUT"]) / 1000) + 30
+            http_timeout = aiohttp.ClientTimeout(total=_total)
         else:
-            http_timeout = aiohttp.ClientTimeout(sock_connect=30, total=None)
+            http_timeout = aiohttp.ClientTimeout(total=None)
 
         conn_err = None
         try:

--- a/pyTigerGraph/pytgasync/pyTigerGraphBase.py
+++ b/pyTigerGraph/pytgasync/pyTigerGraphBase.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 class AsyncPyTigerGraphBase(PyTigerGraphCore):
     def __init__(self, host: str = "http://127.0.0.1", graphname: str = "",
                  gsqlSecret: str = "", username: str = "tigergraph", password: str = "tigergraph",
-                 tgCloud: bool = False, restppPort: Union[int, str] = "9000",
-                 gsPort: Union[int, str] = "14240", gsqlVersion: str = "", version: str = "",
+                 tgCloud: bool = False, restppPort: Union[int, str] = None,
+                 gsPort: Union[int, str] = None, gsqlVersion: str = "", version: str = "",
                  apiToken: str = "", useCert: bool = None, certPath: str = None, debug: bool = None,
                  sslPort: Union[int, str] = "443", gcp: bool = False, jwtToken: str = ""):
         """Initiate a connection object (doc string copied from synchronous __init__).

--- a/pyTigerGraph/pytgasync/pyTigerGraphLoading.py
+++ b/pyTigerGraph/pytgasync/pyTigerGraphLoading.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 class AsyncPyTigerGraphLoading(AsyncPyTigerGraphBase):
 
     async def runLoadingJobWithDataFrame(self, df: 'pd.DataFrame', fileTag: str, jobName: str, sep: str = None,
-                                         eol: str = None, timeout: int = 16000, sizeLimit: int = 128000000, columns: list = None) -> Union[dict, None]:
+                                         eol: str = None, timeout: int = 0, sizeLimit: int = 128000000, columns: list = None) -> Union[dict, None]:
         """Execute a loading job with the given pandas DataFrame with optional column list.
 
         The data string will be posted to the TigerGraph server and the value of the appropriate
@@ -86,7 +86,7 @@ class AsyncPyTigerGraphLoading(AsyncPyTigerGraphBase):
         return res
 
     async def runLoadingJobWithFile(self, filePath: str, fileTag: str, jobName: str, sep: str = None,
-                                    eol: str = None, timeout: int = 16000, sizeLimit: int = 128000000) -> Union[dict, None]:
+                                    eol: str = None, timeout: int = 0, sizeLimit: int = 128000000) -> Union[dict, None]:
         """Execute a loading job with the referenced file.
 
         The file will first be uploaded to the TigerGraph server and the value of the appropriate
@@ -129,7 +129,7 @@ class AsyncPyTigerGraphLoading(AsyncPyTigerGraphBase):
         return res
 
     async def runLoadingJobWithData(self, data: str, fileTag: str, jobName: str, sep: str = None,
-                                    eol: str = None, timeout: int = 16000, sizeLimit: int = 128000000) -> Union[dict, None]:
+                                    eol: str = None, timeout: int = 0, sizeLimit: int = 128000000) -> Union[dict, None]:
         """Execute a loading job with the given data string.
 
         The data string will be posted to the TigerGraph server and the value of the appropriate
@@ -193,7 +193,7 @@ class AsyncPyTigerGraphLoading(AsyncPyTigerGraphBase):
 
         return res
 
-    async def uploadFile(self, filePath, fileTag, jobName="", sep=None, eol=None, timeout=16000,
+    async def uploadFile(self, filePath, fileTag, jobName="", sep=None, eol=None, timeout=0,
                          sizeLimit=128000000) -> dict:
         """DEPRECATED
 

--- a/pyTigerGraph/pytgasync/pyTigerGraphSchema.py
+++ b/pyTigerGraph/pytgasync/pyTigerGraphSchema.py
@@ -541,12 +541,16 @@ class AsyncPyTigerGraphSchema(AsyncPyTigerGraphBase):
 
         return res
 
-    async def dropGraph(self, graphName: str) -> dict:
+    async def dropGraph(self, graphName: str, cascade: bool = False) -> dict:
         """Drops a graph and all its data.
 
         Args:
             graphName:
                 Name of the graph to drop.
+            cascade:
+                When True, automatically removes associated queries and loading jobs.
+                When False (default), the operation fails if related queries or loading
+                jobs exist. Only supported on TigerGraph >= 4.0.
 
         Returns:
             A dict with at least a ``"message"`` key describing the outcome.
@@ -558,12 +562,15 @@ class AsyncPyTigerGraphSchema(AsyncPyTigerGraphBase):
         logger.debug("entry: dropGraph")
 
         if await self._version_greater_than_4_0():
+            params = {"cascade": str(cascade).lower()} if cascade else None
             res = await self._req("DELETE", self.gsUrl + "/gsql/v1/schema/graphs/" + graphName,
-                                 authMode="pwd", resKey=None,
+                                 authMode="pwd", resKey=None, params=params,
                                  headers={'Content-Type': 'application/json'})
         else:
-            res = _wrap_gsql_result(
-                await self.gsql(f"DROP GRAPH {graphName}"))
+            cmd = f"DROP GRAPH {graphName}"
+            if cascade:
+                cmd += " CASCADE"
+            res = _wrap_gsql_result(await self.gsql(cmd))
 
         if logger.level == logging.DEBUG:
             logger.debug("return: " + str(res))

--- a/pyTigerGraph/pytgasync/pyTigerGraphSchema.py
+++ b/pyTigerGraph/pytgasync/pyTigerGraphSchema.py
@@ -550,7 +550,7 @@ class AsyncPyTigerGraphSchema(AsyncPyTigerGraphBase):
             cascade:
                 When True, automatically removes associated queries and loading jobs.
                 When False (default), the operation fails if related queries or loading
-                jobs exist. Only supported on TigerGraph >= 4.0.
+                jobs exist.
 
         Returns:
             A dict with at least a ``"message"`` key describing the outcome.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyTigerGraph"
 version = "2.0.2"
 description = "Library to connect to TigerGraph databases"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [{ name = "TigerGraph Inc.", email = "support@tigergraph.com" }]
 requires-python = ">=3.8"
 keywords = ["TigerGraph", "Graph Database", "Data Science", "Machine Learning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyTigerGraph"
-version = "2.0.2"
+version = "2.0.3"
 description = "Library to connect to TigerGraph databases"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pytigergraph-recipe/recipe/meta.yaml
+++ b/pytigergraph-recipe/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/pytigergraph/pytigergraph-{{ version }}.tar.gz
-  sha256: b92ab1707b75c3046214f42c38158ed16ad7683cd9687f409f95e621bcd6a53e
+  # sha256:
 
 build:
   number: 0

--- a/pytigergraph-recipe/recipe/meta.yaml
+++ b/pytigergraph-recipe/recipe/meta.yaml
@@ -1,12 +1,13 @@
+{% set version = "2.0.3" %}
 {% set python_min = "3.9" %}
 
 package:
   name: pytigergraph
-  version: "2.0.2"
+  version: "{{ version }}"
 
 source:
-  url: https://pypi.org/packages/source/p/pytigergraph/pytigergraph-2.0.2.tar.gz
-  # sha256: update after publishing to PyPI
+  url: https://pypi.org/packages/source/p/pytigergraph/pytigergraph-{{ version }}.tar.gz
+  sha256: b92ab1707b75c3046214f42c38158ed16ad7683cd9687f409f95e621bcd6a53e
 
 build:
   number: 0

--- a/tests/test_v202_changes.py
+++ b/tests/test_v202_changes.py
@@ -932,5 +932,120 @@ class TestHostPortExtraction(unittest.TestCase):
         self.assertEqual(conn.host, "https://myserver.tgcloud.io")
 
 
+class TestHttpTimeoutFromGsqlTimeout(unittest.TestCase):
+    """Tests for HTTP timeout derivation from GSQL-TIMEOUT header.
+
+    Verifies that:
+    - GSQL-TIMEOUT > 0 sets both connect and read timeouts to the same value
+      (so large uploads don't hit a 30s socket timeout during sendall).
+    - GSQL-TIMEOUT = 0 uses no client-side timeout (server-wide timeout).
+    - Per-request headers override responseConfigHeader.
+    """
+
+    def _capture_timeout(self, conn, gsql_timeout):
+        """Call _req with a given GSQL-TIMEOUT and return the timeout passed to _do_request."""
+        captured = {}
+
+        def fake_do_request(method, url, headers, data, jsonData, params, timeout):
+            captured["timeout"] = timeout
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b'{"results": []}'
+            resp.json.return_value = {"results": []}
+            return resp
+
+        with patch.object(conn, "_do_request", side_effect=fake_do_request):
+            conn._req("POST", conn.restppUrl + "/ddl/testgraph",
+                       headers={"GSQL-TIMEOUT": str(gsql_timeout),
+                                "RESPONSE-LIMIT": "128000000"})
+        return captured["timeout"]
+
+    def test_gsql_timeout_positive_sets_timeout(self):
+        """GSQL-TIMEOUT=600000 should give 630."""
+        conn = _make_conn()
+        timeout = self._capture_timeout(conn, 600000)
+        self.assertEqual(timeout, 630)
+
+    def test_gsql_timeout_zero_gives_no_timeout(self):
+        """GSQL-TIMEOUT=0 should give None (no client-side limit)."""
+        conn = _make_conn()
+        timeout = self._capture_timeout(conn, 0)
+        self.assertIsNone(timeout)
+
+    def test_gsql_timeout_small_value(self):
+        """GSQL-TIMEOUT=16000 should give 46."""
+        conn = _make_conn()
+        timeout = self._capture_timeout(conn, 16000)
+        self.assertEqual(timeout, 46)
+
+    def test_per_request_header_overrides_response_config(self):
+        """Per-request GSQL-TIMEOUT should override responseConfigHeader."""
+        conn = _make_conn()
+        conn.customizeHeader(timeout=300000)  # responseConfigHeader: 300000
+        # Per-request header: 600000 should win
+        timeout = self._capture_timeout(conn, 600000)
+        self.assertEqual(timeout, 630)
+
+    def test_response_config_header_used_when_no_per_request(self):
+        """responseConfigHeader GSQL-TIMEOUT used when no per-request header."""
+        conn = _make_conn()
+        conn.customizeHeader(timeout=300000)
+
+        captured = {}
+        def fake_do_request(method, url, headers, data, jsonData, params, timeout):
+            captured["timeout"] = timeout
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b'{"results": []}'
+            resp.json.return_value = {"results": []}
+            return resp
+
+        with patch.object(conn, "_do_request", side_effect=fake_do_request):
+            conn._req("GET", conn.restppUrl + "/some/endpoint")
+        # responseConfigHeader sets GSQL-TIMEOUT=300000 → 330
+        self.assertEqual(captured["timeout"], 330)
+
+    def test_loading_job_timeout_passed_correctly(self):
+        """runLoadingJobWithData with timeout=600000 should use 630."""
+        conn = _make_conn()
+        conn.customizeHeader(timeout=300000)
+
+        captured = {}
+        def fake_do_request(method, url, headers, data, jsonData, params, timeout):
+            captured["timeout"] = timeout
+            captured["headers"] = headers
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b'{"results": []}'
+            resp.json.return_value = {"results": []}
+            return resp
+
+        with patch.object(conn, "_do_request", side_effect=fake_do_request):
+            conn.runLoadingJobWithData("line1\nline2\n", "f1", "job1",
+                                       timeout=600000)
+        # Per-request GSQL-TIMEOUT=600000 overrides responseConfigHeader=300000
+        self.assertEqual(captured["headers"]["GSQL-TIMEOUT"], "600000")
+        self.assertEqual(captured["timeout"], 630)
+
+    def test_loading_job_default_timeout_zero(self):
+        """runLoadingJobWithData default timeout=0 should use no client limit."""
+        conn = _make_conn()
+
+        captured = {}
+        def fake_do_request(method, url, headers, data, jsonData, params, timeout):
+            captured["timeout"] = timeout
+            captured["headers"] = headers
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b'{"results": []}'
+            resp.json.return_value = {"results": []}
+            return resp
+
+        with patch.object(conn, "_do_request", side_effect=fake_do_request):
+            conn.runLoadingJobWithData("line1\nline2\n", "f1", "job1")
+        self.assertEqual(captured["headers"]["GSQL-TIMEOUT"], "0")
+        self.assertIsNone(captured["timeout"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_v202_changes.py
+++ b/tests/test_v202_changes.py
@@ -850,5 +850,87 @@ class TestCreateSchemaChangeJobContentType(unittest.TestCase):
         self.assertEqual(kwargs["headers"]["Content-Type"], "application/json")
 
 
+class TestHostPortExtraction(unittest.TestCase):
+    """Tests for extracting port from host URL."""
+
+    def test_port_in_url_sets_restpp_and_gs_port(self):
+        """Port in URL should be used as restppPort and gsPort."""
+        conn = _make_conn(host="http://192.168.11.11:14240")
+        self.assertEqual(conn.host, "http://192.168.11.11")
+        self.assertEqual(conn.restppPort, "14240")
+        self.assertEqual(conn.gsPort, "14240")
+        self.assertIn("14240", conn.restppUrl)
+        self.assertNotIn("14240:14240", conn.restppUrl)
+
+    def test_port_in_url_no_double_port(self):
+        """URLs should never contain double ports."""
+        conn = _make_conn(host="http://192.168.11.11:14240")
+        self.assertNotIn(":14240:14240", conn.restppUrl)
+        self.assertNotIn(":14240:14240", conn.gsUrl)
+
+    def test_no_port_in_url_uses_defaults(self):
+        """Without port in URL, default ports should be used."""
+        conn = _make_conn(host="http://192.168.11.11")
+        self.assertEqual(conn.host, "http://192.168.11.11")
+        self.assertEqual(conn.restppPort, "9000")
+        self.assertEqual(conn.gsPort, "14240")
+
+    def test_port_in_url_with_matching_restpp_port(self):
+        """Explicit restppPort matching URL port should work."""
+        conn = _make_conn(host="http://192.168.11.11:14240", restppPort="14240")
+        self.assertEqual(conn.restppPort, "14240")
+
+    def test_port_in_url_conflicts_with_restpp_port(self):
+        """Explicit non-default restppPort differing from URL port should raise."""
+        with self.assertRaises(TigerGraphException) as ctx:
+            _make_conn(host="http://192.168.11.11:14240", restppPort="7000")
+        self.assertIn("conflicts", str(ctx.exception))
+
+    def test_port_in_url_with_only_gs_port_matching(self):
+        """Explicit gsPort matching URL port: OK, URL port also sets restppPort."""
+        conn = _make_conn(host="http://192.168.11.11:10000", gsPort="10000")
+        self.assertEqual(conn.restppPort, "10000")
+        self.assertEqual(conn.gsPort, "10000")
+
+    def test_port_in_url_conflicts_with_gs_port(self):
+        """Explicit gsPort (only) differing from URL port: error."""
+        with self.assertRaises(TigerGraphException) as ctx:
+            _make_conn(host="http://192.168.11.11:7000", gsPort="10000")
+        self.assertIn("conflicts", str(ctx.exception))
+
+    def test_both_ports_explicit_url_matches_restpp(self):
+        """Both explicit, URL port matches restppPort: OK."""
+        conn = _make_conn(host="http://192.168.11.11:7000",
+                          restppPort="7000", gsPort="10000")
+        self.assertEqual(conn.host, "http://192.168.11.11")
+        self.assertEqual(conn.restppPort, "7000")
+        self.assertEqual(conn.gsPort, "10000")
+
+    def test_both_ports_explicit_url_matches_gs(self):
+        """Both explicit, URL port matches gsPort: OK."""
+        conn = _make_conn(host="http://192.168.11.11:10000",
+                          restppPort="7000", gsPort="10000")
+        self.assertEqual(conn.host, "http://192.168.11.11")
+        self.assertEqual(conn.restppPort, "7000")
+        self.assertEqual(conn.gsPort, "10000")
+
+    def test_both_ports_explicit_url_matches_neither(self):
+        """Both explicit, URL port matches neither: error."""
+        with self.assertRaises(TigerGraphException) as ctx:
+            _make_conn(host="http://192.168.11.11:5000",
+                       restppPort="7000", gsPort="10000")
+        self.assertIn("conflicts", str(ctx.exception))
+
+    def test_port_in_url_with_matching_gs_port(self):
+        """Explicit gsPort matching URL port should work."""
+        conn = _make_conn(host="http://192.168.11.11:14240", gsPort="14240")
+        self.assertEqual(conn.gsPort, "14240")
+
+    def test_https_with_port(self):
+        """HTTPS URL with port should work correctly."""
+        conn = _make_conn(host="https://myserver.tgcloud.io:443")
+        self.assertEqual(conn.host, "https://myserver.tgcloud.io")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Fix host URL port extraction
  - Prevent double-port request URLs
  - Validate URL and explicit port conflicts
  - Apply defaults only when unset

- Correct timeout and header precedence
  - Use single HTTP timeout value
  - Let request headers override defaults
  - Default loading timeout to server-managed

- Add graph drop cascade support
  - Support `cascade` in sync and async schema APIs
  - Use query param or GSQL fallback

- Release `2.0.3` packaging updates
  - Update changelog and project version
  - Fix PEP 639 license metadata
  - Refresh conda recipe handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  host["Host URL with optional port"]
  parse["Extract hostname and port"]
  validate["Validate against explicit ports"]
  urls["Build clean `host`, `restppUrl`, `gsUrl`"]
  headers["Merge default and request headers"]
  timeout["Derive single HTTP timeout"]
  loading["Loading jobs use default `timeout=0`"]
  drop["`dropGraph(cascade=...)` support"]
  tests["Regression tests added"]

  host -- "parsed by" --> parse
  parse -- "checks conflicts" --> validate
  validate -- "produces" --> urls
  headers -- "drives" --> timeout
  timeout -- "used by" --> loading
  urls -- "covered by" --> tests
  timeout -- "covered by" --> tests
  drop -- "covered in API changes" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>base.py</strong><dd><code>Parse host URL ports and fix header precedence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-91278191ade3843df1fe920c441bc52bb8ea1ede5b8dd6b44bd1ba6b82039562">+41/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraphBase.py</strong><dd><code>Use single HTTP timeout value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-73b6fd18165b72ae5c01f87a492652bc10f092c715849227201f2d180d595830">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraphLoading.py</strong><dd><code>Default loading job timeout to zero</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-7469b50a00a1ae79c4f508c7c15e9e56071c5aaf7778259348753380f7c6205d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraphBase.py</strong><dd><code>Align async timeout handling with sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-5337ebbdbf93300fdc12bd15facfd539ed28b23dd65c4b395e6789efa53e8db7">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraphLoading.py</strong><dd><code>Default async loading timeout to zero</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-cc7c12a5ff803e75b988b484aebc9fd81d24c00aefb18ab85bc29eb5c49ae75c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>pyTigerGraph.py</strong><dd><code>Allow unset default connection ports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-049869324bc9b61220c2f94015481f1384417c7458e5b6a87d8ea949e6c5ca0b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraphSchema.py</strong><dd><code>Add cascade option to graph deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-6e7a00ee72556bcd42f9ec848e63804c9cf0faea342e30832b2ace5186d84ff4">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraph.py</strong><dd><code>Allow unset default async connection ports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-e6eb242d5d8ab86d36b1b495cb7be9d8bbd93c0ab30263339df51f5a1b253e94">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyTigerGraphSchema.py</strong><dd><code>Add async cascade graph deletion support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-eb5a4d91388347fb875654a47cb37de0972bac81b0bdc7f76b34a51a58671ea7">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_v202_changes.py</strong><dd><code>Add regression tests for ports and timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-82283b1d694684323e199e03e507fa957b28e2eb7de033c843f4b92448c6dab8">+197/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>build.sh</strong><dd><code>Simplify conda recipe version and sha update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823">+8/-41</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong><dd><code>Bump version and fix license metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>meta.yaml</strong><dd><code>Template recipe version and set sha256</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-5895829f5937eee00faadaf79d016e9df16151f27da6d9020ac51badc1f23439">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document `2.0.3` fixes and release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tigergraph/pyTigerGraph/pull/286/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

